### PR TITLE
[main][fix] Flashloan validation

### DIFF
--- a/script/deployments/libraries/LibMoneyMarketDeployment.sol
+++ b/script/deployments/libraries/LibMoneyMarketDeployment.sol
@@ -264,7 +264,7 @@ library LibMoneyMarketDeployment {
     _selectors[20] = IAdminFacet.setAccountManagersOk.selector;
     _selectors[21] = IAdminFacet.setTokenMaximumCapacities.selector;
     _selectors[22] = IAdminFacet.setRiskManagersOk.selector;
-    _selectors[23] = IAdminFacet.setFlashloanFees.selector;
+    _selectors[23] = IAdminFacet.setFlashloanParams.selector;
   }
 
   function getLiquidationFacetSelectors() internal pure returns (bytes4[] memory _selectors) {

--- a/solidity/contracts/money-market/facets/AdminFacet.sol
+++ b/solidity/contracts/money-market/facets/AdminFacet.sol
@@ -42,7 +42,7 @@ contract AdminFacet is IAdminFacet {
   event LogSetAccountManagerOk(address indexed _manager, bool isOk);
   event LogSetLiquidationTreasury(address indexed _treasury);
   event LogSetFees(uint256 _lendingFeeBps, uint256 _repurchaseFeeBps, uint256 _liquidationFeeBps);
-  event LogSetFlashloanFees(uint256 _flashloanFeeBps, uint256 _lenderFlashloanBps);
+  event LogSetFlashloanParams(uint256 _flashloanFeeBps, uint256 _lenderFlashloanBps, address _flashloanTreasury);
   event LogSetRepurchaseRewardModel(IFeeModel indexed _repurchaseRewardModel);
   event LogSetIbTokenImplementation(address indexed _newImplementation);
   event LogSetDebtTokenImplementation(address indexed _newImplementation);
@@ -386,19 +386,25 @@ contract AdminFacet is IAdminFacet {
     emit LogSetFees(_newLendingFeeBps, _newRepurchaseFeeBps, _newLiquidationFeeBps);
   }
 
-  /// @notice Set lender portion and flashloan fee
+  /// @notice Set parameters for flashloan
   /// @param _flashloanFeeBps the flashloan fee collected by protocol
   /// @param _lenderFlashloanBps the portion that lenders will receive from _flashloanFeeBps
-  function setFlashloanFees(uint16 _flashloanFeeBps, uint16 _lenderFlashloanBps) external onlyOwner {
+  /// @param _flashloanTreasury the address that hold excess flashloan fee
+  function setFlashloanParams(
+    uint16 _flashloanFeeBps,
+    uint16 _lenderFlashloanBps,
+    address _flashloanTreasury
+  ) external onlyOwner {
     if (_flashloanFeeBps > LibConstant.MAX_BPS || _lenderFlashloanBps > LibConstant.MAX_BPS) {
       revert AdminFacet_InvalidArguments();
     }
     LibMoneyMarket01.MoneyMarketDiamondStorage storage moneyMarketDs = LibMoneyMarket01.moneyMarketDiamondStorage();
-    // Replace existing fees
+    // Replace existing params
     moneyMarketDs.flashloanFeeBps = _flashloanFeeBps;
     moneyMarketDs.lenderFlashloanBps = _lenderFlashloanBps;
+    moneyMarketDs.flashloanTreasury = _flashloanTreasury;
 
-    emit LogSetFlashloanFees(_flashloanFeeBps, _lenderFlashloanBps);
+    emit LogSetFlashloanParams(_flashloanFeeBps, _lenderFlashloanBps, _flashloanTreasury);
   }
 
   /// @notice Set the repurchase reward model for a token specifically to over collateralized borrowing

--- a/solidity/contracts/money-market/facets/FlashloanFacet.sol
+++ b/solidity/contracts/money-market/facets/FlashloanFacet.sol
@@ -33,6 +33,11 @@ contract FlashloanFacet is IFlashloanFacet {
   ) external nonReentrant {
     LibMoneyMarket01.MoneyMarketDiamondStorage storage moneyMarketDs = LibMoneyMarket01.moneyMarketDiamondStorage();
 
+    // only allow flashloan on opened market
+    if (moneyMarketDs.tokenToIbTokens[_token] == address(0)) {
+      revert FlashloanFacet_InvalidToken(_token);
+    }
+
     // expected fee = (_amount * flashloan fee (bps)) / max bps
     uint256 _expectedFee = (_amount * moneyMarketDs.flashloanFeeBps) / LibConstant.MAX_BPS;
 

--- a/solidity/contracts/money-market/facets/FlashloanFacet.sol
+++ b/solidity/contracts/money-market/facets/FlashloanFacet.sol
@@ -21,6 +21,15 @@ contract FlashloanFacet is IFlashloanFacet {
     LibReentrancyGuard.unlock();
   }
 
+  // Event
+  event LogFlashloan(
+    address _token,
+    uint256 _amount,
+    uint256 _feeToLenders,
+    uint256 _feeToProtocol,
+    uint256 _excessFee
+  );
+
   /// @notice Loan token and pay it back, plus fee, in the callback
   /// @dev The caller of this method receives a callback in the form of IAlpacaFlashloanCallback#alpacaFlashloanCallback
   /// @param _token The address of loan token
@@ -35,11 +44,15 @@ contract FlashloanFacet is IFlashloanFacet {
 
     // only allow flashloan on opened market
     if (moneyMarketDs.tokenToIbTokens[_token] == address(0)) {
-      revert FlashloanFacet_InvalidToken(_token);
+      revert FlashloanFacet_InvalidToken();
     }
 
     // expected fee = (_amount * flashloan fee (bps)) / max bps
     uint256 _expectedFee = (_amount * moneyMarketDs.flashloanFeeBps) / LibConstant.MAX_BPS;
+
+    if (_expectedFee == 0) {
+      revert FlashloanFacet_NoFee();
+    }
 
     // cache balance before sending token to flashloaner
     uint256 _balanceBefore = IERC20(_token).balanceOf(address(this));
@@ -54,16 +67,30 @@ contract FlashloanFacet is IFlashloanFacet {
       revert FlashloanFacet_NotEnoughRepay();
     }
 
-    // calculate the actual lender fee by taking x% of expected fee
+    // transfer excess fee to treasury
     // in case flashloaner inject a lot of fee, the ib token price should not be inflated
     // this is to prevent unforeseeable impact from inflating the ib token price
-    uint256 _lenderFee = (_expectedFee * moneyMarketDs.lenderFlashloanBps) / LibConstant.MAX_BPS;
+    uint256 _excessFee;
+    if (_actualTotalFee > _expectedFee) {
+      unchecked {
+        _excessFee = _actualTotalFee - _expectedFee;
+      }
 
-    // total actual fee will be added to reserve (including excess fee)
-    moneyMarketDs.reserves[_token] += _actualTotalFee;
+      IERC20(_token).safeTransfer(moneyMarketDs.flashloanTreasury, _excessFee);
+    }
+
+    // calculate the actual lender fee by taking x% of expected fee
+    uint256 _feeToLenders = (_expectedFee * moneyMarketDs.lenderFlashloanBps) / LibConstant.MAX_BPS;
+
+    // expected fee will be added to reserve
+    moneyMarketDs.reserves[_token] += _expectedFee;
     // the rest of the fee will go to protocol
-    moneyMarketDs.protocolReserves[_token] += _actualTotalFee - _lenderFee;
+    uint256 _feeToProtocol;
+    unchecked {
+      _feeToProtocol = _expectedFee - _feeToLenders;
+    }
+    moneyMarketDs.protocolReserves[_token] += _feeToProtocol;
 
-    emit LogFlashloan(_token, _amount, _actualTotalFee, _lenderFee);
+    emit LogFlashloan(_token, _amount, _feeToLenders, _feeToProtocol, _excessFee);
   }
 }

--- a/solidity/contracts/money-market/interfaces/IAdminFacet.sol
+++ b/solidity/contracts/money-market/interfaces/IAdminFacet.sol
@@ -85,7 +85,11 @@ interface IAdminFacet {
     uint16 _newLiquidationFeeBps
   ) external;
 
-  function setFlashloanFees(uint16 _flashloanFeeBps, uint16 _lenderFlashloanBps) external;
+  function setFlashloanParams(
+    uint16 _flashloanFeeBps,
+    uint16 _lenderFlashloanBps,
+    address _flashloanTreasury
+  ) external;
 
   function setRepurchaseRewardModel(IFeeModel _newRepurchaseRewardModel) external;
 

--- a/solidity/contracts/money-market/interfaces/IFlashloanFacet.sol
+++ b/solidity/contracts/money-market/interfaces/IFlashloanFacet.sol
@@ -2,13 +2,11 @@
 pragma solidity 0.8.19;
 
 interface IFlashloanFacet {
-  // Event
-  event LogFlashloan(address token, uint256 amount, uint256 totalFee, uint256 lenderFee);
-
   // Errors
-  error FlashloanFacet_InvalidToken(address _token);
+  error FlashloanFacet_InvalidToken();
   error FlashloanFacet_NotEnoughToken(uint256 _amount);
   error FlashloanFacet_NotEnoughRepay();
+  error FlashloanFacet_NoFee();
 
   /// @notice Receive token0 and/or token1 and pay it back, plus a fee, in the callback
   /// @dev The caller of this method receives a callback in the form of IAlpacaFlashloanCallback#alpacaFlashloanCallback

--- a/solidity/contracts/money-market/libraries/LibMoneyMarket01.sol
+++ b/solidity/contracts/money-market/libraries/LibMoneyMarket01.sol
@@ -152,6 +152,7 @@ library LibMoneyMarket01 {
     uint16 liquidationFeeBps; // fee that is charged during liquidation by protocol, goes to liquidationTreasury
     uint16 flashloanFeeBps; // fee that is charged when providing the flashloan
     uint16 lenderFlashloanBps; // portion of flashloan fee that will go to lenders
+    address flashloanTreasury; // a treasury to hold excess flashloan fee
   }
 
   /// @dev Get money market storage

--- a/solidity/tests/money-market/MoneyMarket_BaseTest.t.sol
+++ b/solidity/tests/money-market/MoneyMarket_BaseTest.t.sol
@@ -226,11 +226,7 @@ abstract contract MoneyMarket_BaseTest is BaseTest {
     adminFacet.setLiquidationTreasury(liquidationTreasury);
 
     // adminFacet.setFees(_newLendingFeeBps, _newRepurchaseFeeBps, _newLiquidationFeeBps);
-
     adminFacet.setFees(0, 100, 100);
-
-    // adminFacet.setFlashloanFees(_flashloanFeeBps, _lenderFlashloanBps);
-    adminFacet.setFlashloanFees(500, 5000);
 
     // set liquidation params: maxLiquidate 50%, liquidationThreshold 111.11%
     adminFacet.setLiquidationParams(5000, 11111);

--- a/solidity/tests/money-market/flashloan/MoneyMarket_Flashloan.t.sol
+++ b/solidity/tests/money-market/flashloan/MoneyMarket_Flashloan.t.sol
@@ -19,6 +19,7 @@ import { MockFlashloan_Repurchase } from "../../mocks/MockFlashloan_Repurchase.s
 
 contract MoneyMarket_Flashloan is MoneyMarket_BaseTest {
   MockFlashloan internal mockFlashloan;
+  address internal flashloanTreasury;
 
   struct RepurchaseParam {
     address _account;
@@ -30,6 +31,8 @@ contract MoneyMarket_Flashloan is MoneyMarket_BaseTest {
 
   function setUp() public override {
     super.setUp();
+    flashloanTreasury = address(111);
+    adminFacet.setFlashloanParams(500, 5000, flashloanTreasury);
 
     mockFlashloan = new MockFlashloan(moneyMarketDiamond);
     // add 5 usdc to mock flashloan contract
@@ -107,13 +110,15 @@ contract MoneyMarket_Flashloan is MoneyMarket_BaseTest {
     // fee = 0.05 USDC
     // After flash, reserve = current + fee + extra
     // 10 + 0.05 + 1 = 11.05 USDC #
-    // Extra 1 USDC should go to protocol reserve
-    // protocol reserve = current + fee + extra = 0 + 0.025 + 1 = 1.025 USDC #
+    // Extra 1 USDC should go to flashloan treasury
+    // protocol reserve = current + fee = 0 + 0.025  = 0.025 USDC #
     uint256 _reserve = viewFacet.getFloatingBalance(address(usdc));
-    assertEq(_reserve, normalizeEther(11.05 ether, usdcDecimal), "Reserve");
+    assertEq(_reserve, normalizeEther(10.05 ether, usdcDecimal), "Reserve");
 
     uint256 _protocolReserve = viewFacet.getProtocolReserve(address(usdc));
-    assertEq(_protocolReserve, normalizeEther(1.025 ether, usdcDecimal), "Protocol reserve");
+    assertEq(_protocolReserve, normalizeEther(0.025 ether, usdcDecimal), "Protocol reserve");
+
+    assertEq(usdc.balanceOf(flashloanTreasury), normalizeEther(1 ether, usdcDecimal), "Flashloan Treasury");
   }
 
   // test if repay less than the expected fee (should revert)
@@ -185,5 +190,17 @@ contract MoneyMarket_Flashloan is MoneyMarket_BaseTest {
       vm.expectRevert(LibReentrancyGuard.LibReentrancyGuard_ReentrantCall.selector);
       _mockRepurchaseFlashloan.flash(address(usdc), _flashloanAmount, _data);
     }
+  }
+
+  function testRevert_IfExpectedFeeIsZero_ShouldRevert() external {
+    // this should cause precision loss on expected fee
+    vm.expectRevert(IFlashloanFacet.FlashloanFacet_NoFee.selector);
+    mockFlashloan.flash(address(usdc), 10, "");
+  }
+
+  function testRevert_WhenTryToFlashloanNonExistingMarket_ShouldRevert() external {
+    // this should cause precision loss on expected fee
+    vm.expectRevert(IFlashloanFacet.FlashloanFacet_InvalidToken.selector);
+    mockFlashloan.flash(address(888), 10, "");
   }
 }

--- a/solidity/tests/money-market/flashloan/MoneyMarket_Flashloan.t.sol
+++ b/solidity/tests/money-market/flashloan/MoneyMarket_Flashloan.t.sol
@@ -199,7 +199,6 @@ contract MoneyMarket_Flashloan is MoneyMarket_BaseTest {
   }
 
   function testRevert_WhenTryToFlashloanNonExistingMarket_ShouldRevert() external {
-    // this should cause precision loss on expected fee
     vm.expectRevert(IFlashloanFacet.FlashloanFacet_InvalidToken.selector);
     mockFlashloan.flash(address(888), 10, "");
   }


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
- only allow flashloan on opened market
- revert if expectedFee = 0
- transfer excess to treasury

## Why?
<!--- Why is this change required? What problem does it solve? -->

## ChangeLogs:
<!--- changes for this pr -->


### Link to story (if available)
<!--- Add story URL here -->
