### PR TITLE
[main][feat] add "getNonCollatPendingInterest" function

### DIFF
--- a/script/deployments/libraries/LibMoneyMarketDeployment.sol
+++ b/script/deployments/libraries/LibMoneyMarketDeployment.sol
@@ -166,7 +166,7 @@ library LibMoneyMarketDeployment {
   }
 
   function getViewFacetSelectors() internal pure returns (bytes4[] memory _selectors) {
-    _selectors = new bytes4[](48);
+    _selectors = new bytes4[](49);
     _selectors[0] = IViewFacet.getProtocolReserve.selector;
     _selectors[1] = IViewFacet.getTokenConfig.selector;
     _selectors[2] = IViewFacet.getOverCollatDebtSharesOf.selector;
@@ -215,6 +215,7 @@ library LibMoneyMarketDeployment {
     _selectors[45] = IViewFacet.isAccountManagersOk.selector;
     _selectors[46] = IViewFacet.isRiskManagersOk.selector;
     _selectors[47] = IViewFacet.isOperatorsOk.selector;
+    _selectors[48] = IViewFacet.getNonCollatPendingInterest.selector;
   }
 
   function getLendFacetSelectors() internal pure returns (bytes4[] memory _selectors) {

--- a/solidity/contracts/money-market/facets/ViewFacet.sol
+++ b/solidity/contracts/money-market/facets/ViewFacet.sol
@@ -151,7 +151,7 @@ contract ViewFacet is IViewFacet {
 
   /// @notice Get pending interest of non collateralized borrowed token
   /// @param _account The non collat borrower address
-  /// @param _token The token that has collected the interest
+  /// @param _token The token that has been borrowed
   /// @return _pendingInterest The total amount of non collateralized pending interest
   function getNonCollatPendingInterest(address _account, address _token)
     external

--- a/solidity/contracts/money-market/interfaces/IViewFacet.sol
+++ b/solidity/contracts/money-market/interfaces/IViewFacet.sol
@@ -46,6 +46,11 @@ interface IViewFacet {
 
   function getOverCollatPendingInterest(address _token) external view returns (uint256 _pendingInterest);
 
+  function getNonCollatPendingInterest(address _account, address _token)
+    external
+    view
+    returns (uint256 _pendingInterest);
+
   function getGlobalPendingInterest(address _token) external view returns (uint256);
 
   function getGlobalDebtValue(address _token) external view returns (uint256);

--- a/solidity/tests/money-market/accrue-interest/MoneyMarket_AccrueInterest_Borrow.t.sol
+++ b/solidity/tests/money-market/accrue-interest/MoneyMarket_AccrueInterest_Borrow.t.sol
@@ -586,13 +586,13 @@ contract MoneyMarket_AccrueInterest_Borrow is MoneyMarket_BaseTest {
     assertEq(_borrowedUSDValue, 29 ether);
   }
 
-  function testCorrectness_WhenUserBorrowNonCollat_ShouldWork() external {
+  function testCorrectness_WhenUserBorrowNonCollat_NonCollatPendingInterest_ShouldWork() external {
     // 1. borrow non-collat
     vm.prank(ALICE);
     nonCollatBorrowFacet.nonCollatBorrow(address(weth), 9 ether);
 
     // 2. cache "debt before accrue"
-    uint256 _globalDebtBefore = viewFacet.getGlobalDebtValue(address(weth));
+    uint256 _nonCollatDebtBefore = viewFacet.getNonCollatAccountDebt(ALICE, address(weth));
 
     // skip
     skip(100);
@@ -604,9 +604,9 @@ contract MoneyMarket_AccrueInterest_Borrow is MoneyMarket_BaseTest {
     borrowFacet.accrueInterest(address(weth));
 
     // 5. cache "debt after accrue"
-    uint256 _globalDebtAfter = viewFacet.getGlobalDebtValue(address(weth));
+    uint256 _nonCollatDebtAfter = viewFacet.getNonCollatAccountDebt(ALICE, address(weth));
 
     // assert increasing debt (after - before) == _pendingInterest
-    assertEq(_globalDebtAfter - _globalDebtBefore, _pendingInterest);
+    assertEq(_nonCollatDebtAfter - _nonCollatDebtBefore, _pendingInterest);
   }
 }

--- a/solidity/tests/money-market/accrue-interest/MoneyMarket_AccrueInterest_Borrow.t.sol
+++ b/solidity/tests/money-market/accrue-interest/MoneyMarket_AccrueInterest_Borrow.t.sol
@@ -585,4 +585,28 @@ contract MoneyMarket_AccrueInterest_Borrow is MoneyMarket_BaseTest {
     _borrowedUSDValue = viewFacet.getTotalNonCollatUsedBorrowingPower(ALICE);
     assertEq(_borrowedUSDValue, 29 ether);
   }
+
+  function testCorrectness_WhenUserBorrowNonCollat_ShouldWork() external {
+    // 1. borrow non-collat
+    vm.prank(ALICE);
+    nonCollatBorrowFacet.nonCollatBorrow(address(weth), 9 ether);
+
+    // 2. cache "debt before accrue"
+    uint256 _globalDebtBefore = viewFacet.getGlobalDebtValue(address(weth));
+
+    // skip
+    skip(100);
+
+    // 3. cache "pending interest"
+    uint256 _pendingInterest = viewFacet.getNonCollatPendingInterest(ALICE, address(weth));
+
+    // 4. accrue interest
+    borrowFacet.accrueInterest(address(weth));
+
+    // 5. cache "debt after accrue"
+    uint256 _globalDebtAfter = viewFacet.getGlobalDebtValue(address(weth));
+
+    // assert increasing debt (after - before) == _pendingInterest
+    assertEq(_globalDebtAfter - _globalDebtBefore, _pendingInterest);
+  }
 }

--- a/solidity/tests/money-market/accrue-interest/MoneyMarket_AccrueInterest_Borrow.t.sol
+++ b/solidity/tests/money-market/accrue-interest/MoneyMarket_AccrueInterest_Borrow.t.sol
@@ -586,7 +586,7 @@ contract MoneyMarket_AccrueInterest_Borrow is MoneyMarket_BaseTest {
     assertEq(_borrowedUSDValue, 29 ether);
   }
 
-  function testCorrectness_WhenUserBorrowNonCollat_NonCollatPendingInterest_ShouldWork() external {
+  function testCorrectness_WhenUserBorrowNonCollat_ShouldAccrueInterestCorrectly() external {
     // 1. borrow non-collat
     vm.prank(ALICE);
     nonCollatBorrowFacet.nonCollatBorrow(address(weth), 9 ether);


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
- add ``getNonCollatPendingInterest`` function to ``ViewFacet``
- function will return ``pendingInterest`` according to given ``account`` and ``token``

## Why?
<!--- Why is this change required? What problem does it solve? -->

## ChangeLogs:
<!--- changes for this pr -->


### Link to story (if available)
<!--- Add story URL here -->
